### PR TITLE
- [FIX] - Fixed donation command for xcash-wallet-cli binary

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -767,10 +767,7 @@ namespace cryptonote
   {
     switch (decimal_point)
     {
-      case 12:
-      case 9:
       case 6:
-      case 3:
       case 0:
         default_decimal_point = decimal_point;
         break;
@@ -790,16 +787,10 @@ namespace cryptonote
       decimal_point = default_decimal_point;
     switch (std::atomic_load(&default_decimal_point))
     {
-      case 12:
-        return "xcash";
-      case 9:
-        return "millinero";
       case 6:
-        return "micronero";
-      case 3:
-        return "nanonero";
+        return "xcash";
       case 0:
-        return "piconero";
+        return "zachy";
       default:
         ASSERT_MES_AND_THROW("Invalid decimal point specification: " << default_decimal_point);
     }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -181,7 +181,7 @@
 
 #define BLOCKCHAIN_DEFAULT_MIXIN                20
 
-#define PER_KB_FEE_QUANTIZATION_DECIMALS        8
+#define PER_KB_FEE_QUANTIZATION_DECIMALS        6
 
 #define HASH_OF_HASHES_STEP                     256
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2040,7 +2040,7 @@ bool simple_wallet::set_unit(const std::vector<std::string> &args/* = std::vecto
   if (unit == "xcash")
     decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT;
   else if (unit == "zachy")
-    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 2;
+    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 6;
   else
   {
     fail_msg_writer() << tr("invalid unit");

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2039,14 +2039,8 @@ bool simple_wallet::set_unit(const std::vector<std::string> &args/* = std::vecto
 
   if (unit == "xcash")
     decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT;
-  else if (unit == "millinero")
-    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 3;
-  else if (unit == "micronero")
-    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 6;
-  else if (unit == "nanonero")
-    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 9;
-  else if (unit == "piconero")
-    decimal_point = 0;
+  else if (unit == "zachy")
+    decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT - 2;
   else
   {
     fail_msg_writer() << tr("invalid unit");
@@ -2416,7 +2410,7 @@ simple_wallet::simple_wallet()
                                   "  Set the fee to default/unimportant/normal/elevated/priority.\n "
                                   "confirm-missing-payment-id <1|0>\n "
                                   "ask-password <0|1|2   (or never|action|decrypt)>\n "
-                                  "unit <xcash|millinero|micronero|nanonero|piconero>\n "
+                                  "unit <xcash|zachy>\n "
                                   "  Set the default xcash (sub-)unit.\n "
                                   "min-outputs-count [n]\n "
                                   "  Try to keep at least that many outputs of value at least min-outputs-value.\n "
@@ -2710,7 +2704,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     CHECK_SIMPLE_VARIABLE("priority", set_default_priority, tr("0, 1, 2, 3, or 4, or one of ") << join_priority_strings(", "));
     CHECK_SIMPLE_VARIABLE("confirm-missing-payment-id", set_confirm_missing_payment_id, tr("0 or 1"));
     CHECK_SIMPLE_VARIABLE("ask-password", set_ask_password, tr("0|1|2 (or never|action|decrypt)"));
-    CHECK_SIMPLE_VARIABLE("unit", set_unit, tr("xcash, millinero, micronero, nanonero, piconero"));
+    CHECK_SIMPLE_VARIABLE("unit", set_unit, tr("xcash, zachy"));
     CHECK_SIMPLE_VARIABLE("min-outputs-count", set_min_output_count, tr("unsigned integer"));
     CHECK_SIMPLE_VARIABLE("min-outputs-value", set_min_output_value, tr("amount"));
     CHECK_SIMPLE_VARIABLE("merge-destinations", set_merge_destinations, tr("0 or 1"));

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -52,7 +52,7 @@
 #undef XCASH_DEFAULT_LOG_CATEGORY
 #define XCASH_DEFAULT_LOG_CATEGORY "wallet.simplewallet"
 // Hardcode X-CASH's donation address (see #1447)
-constexpr const char XCASH_DONATION_ADDR[] = "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A";
+constexpr const char XCASH_DONATION_ADDR[] = "XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY";
 
 /*!
  * \namespace cryptonote

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -52,7 +52,7 @@
 #undef XCASH_DEFAULT_LOG_CATEGORY
 #define XCASH_DEFAULT_LOG_CATEGORY "wallet.simplewallet"
 // Hardcode X-CASH's donation address (see #1447)
-constexpr const char XCASH_DONATION_ADDR[] = "XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY";
+constexpr const char XCASH_DONATION_ADDR[] = "XCA1hVzVdYV4SSVG4nPvQY3SFBdHA2HbdGWPsTQsMfYehXVu5ESLsDtMg9WZozzBpR3pPcEnW2iMBVKRP1nkm3TD52Kkyq1Qrt";
 
 /*!
  * \namespace cryptonote

--- a/tests/functional_tests/speed.py
+++ b/tests/functional_tests/speed.py
@@ -54,7 +54,7 @@ class SpeedTest():
         daemon = Daemon()
         wallet = Wallet()
 
-        destinations = wallet.make_uniform_destinations('44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A',1,3)
+        destinations = wallet.make_uniform_destinations('XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY',1,3)
 
         self._test_speed_generateblocks(daemon=daemon, blocks=70)
         for i in range(1, 10):
@@ -77,7 +77,7 @@ class SpeedTest():
         print('Test speed of transfer')
         start = time.time()
 
-        destinations = wallet.make_uniform_destinations('44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A',1)
+        destinations = wallet.make_uniform_destinations('XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY',1)
         res = wallet.transfer_split(destinations)
 
         print('generating tx took: ', time.time() - start, 'seconds')

--- a/tests/functional_tests/speed.py
+++ b/tests/functional_tests/speed.py
@@ -54,7 +54,7 @@ class SpeedTest():
         daemon = Daemon()
         wallet = Wallet()
 
-        destinations = wallet.make_uniform_destinations('XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY',1,3)
+        destinations = wallet.make_uniform_destinations('XCA1hVzVdYV4SSVG4nPvQY3SFBdHA2HbdGWPsTQsMfYehXVu5ESLsDtMg9WZozzBpR3pPcEnW2iMBVKRP1nkm3TD52Kkyq1Qrt',1,3)
 
         self._test_speed_generateblocks(daemon=daemon, blocks=70)
         for i in range(1, 10):
@@ -77,7 +77,7 @@ class SpeedTest():
         print('Test speed of transfer')
         start = time.time()
 
-        destinations = wallet.make_uniform_destinations('XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY',1)
+        destinations = wallet.make_uniform_destinations('XCA1hVzVdYV4SSVG4nPvQY3SFBdHA2HbdGWPsTQsMfYehXVu5ESLsDtMg9WZozzBpR3pPcEnW2iMBVKRP1nkm3TD52Kkyq1Qrt',1)
         res = wallet.transfer_split(destinations)
 
         print('generating tx took: ', time.time() - start, 'seconds')

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -37,7 +37,7 @@
 
 TEST(AddressFromTXT, Success)
 {
-  std::string addr = "XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY";
+  std::string addr = "XCA1hVzVdYV4SSVG4nPvQY3SFBdHA2HbdGWPsTQsMfYehXVu5ESLsDtMg9WZozzBpR3pPcEnW2iMBVKRP1nkm3TD52Kkyq1Qrt";
 
   std::string txtr = "oa1:xcash";
   txtr += " recipient_address=";

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -37,9 +37,9 @@
 
 TEST(AddressFromTXT, Success)
 {
-  std::string addr = "46BeWrHpwXmHDpDEUmZBWZfoQpdc6HaERCNmx1pEYL2rAcuwufPN9rXHHtyUA4QVy66qeFQkn6sfK8aHYjA3jk3o1Bv16em";
+  std::string addr = "XCA1X855VCnZhXvjPZrToya58eTZTBGsMgZCXXHmPiz91A1pUxRQHHvaufsgeBxift4beBLoMPNnugWKvMMdj6qQ1MMbFtcCQY";
 
-  std::string txtr = "oa1:xmr";
+  std::string txtr = "oa1:xcash";
   txtr += " recipient_address=";
   txtr += addr;
   txtr += ";";
@@ -58,7 +58,7 @@ TEST(AddressFromTXT, Success)
 
   EXPECT_STREQ(addr.c_str(), res.c_str());
 
-  std::string txtr3 = "foobar oa1:xmr tx_description=\"Donation for X-CASH Development Fund\"; ";
+  std::string txtr3 = "foobar oa1:xcash tx_description=\"Donation to X-CASH Team\"; ";
   txtr3 += "recipient_address=";
   txtr3 += addr;
   txtr3 += "; foobar";
@@ -70,7 +70,7 @@ TEST(AddressFromTXT, Success)
 
 TEST(AddressFromTXT, Failure)
 {
-  std::string txtr = "oa1:xmr recipient_address=not a real address";
+  std::string txtr = "oa1:xcash recipient_address=not a real address";
 
   std::string res = tools::dns_utils::address_from_txt_record(txtr);
 

--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -2073,7 +2073,7 @@ Otherwise, you prove the reserve of the smallest possible amount above &lt;amoun
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
-        <source>xcash, millinero, micronero, nanonero, piconero</source>
+        <source>xcash, zachy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3915,7 +3915,7 @@ Outputs per *: </source>
    Set the fee to default/unimportant/normal/elevated/priority.
  confirm-missing-payment-id &lt;1|0&gt;
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
- unit &lt;xcash|millinero|micronero|nanonero|piconero&gt;
+ unit &lt;xcash|zachy&gt;
    Set the default xcash (sub-)unit.
  min-outputs-count [n]
    Try to keep at least that many outputs of value at least min-outputs-value.

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -2869,7 +2869,7 @@ Attention&#xa0;: Certaines clés d&apos;entrées étant dépensées sont issues 
    Set the fee to default/unimportant/normal/elevated/priority.
  confirm-missing-payment-id &lt;1|0&gt;
  ask-password &lt;0|1|2   (or never|action|decrypt)&gt;
- unit &lt;xcash|millinero|micronero|nanonero|piconero&gt;
+ unit &lt;xcash|zachy&gt;
    Set the default xcash (sub-)unit.
  min-outputs-count [n]
    Try to keep at least that many outputs of value at least min-outputs-value.
@@ -2913,7 +2913,7 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
    Utiliser les frais pour la priorité par défaut/peu importante/normale/élevée/prioritaire.
  confirm-missing-payment-id &lt;1|0&gt;
  ask-password &lt;0|1|2 (ou never|action|decrypt)&gt;
- unit &lt;xcash|millinero|micronero|nanonero|piconero&gt;
+ unit &lt;xcash|zachy&gt;
    Définir la (sous-)unité xcash par défaut.
  min-outputs-count [n]
    Essayer de garder au moins ce nombre de sorties d&apos;une valeur d&apos;au moins min-outputs-value.
@@ -3055,8 +3055,8 @@ subaddress-lookahead &lt;major&gt;:&lt;minor&gt;
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2650"/>
-        <source>xcash, millinero, micronero, nanonero, piconero</source>
-        <translation>xcash, millinero, micronero, nanonero, piconero</translation>
+        <source>xcash, zachy</source>
+        <translation>xcash, zachy</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="2661"/>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -1585,7 +1585,7 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
    Set the fee to default/unimportant/normal/elevated/priority.
  confirm-missing-payment-id &lt;1|0&gt;
  ask-password &lt;1|0&gt;
- unit &lt;xcash|millinero|micronero|nanonero|piconero&gt;
+ unit &lt;xcash|zachy&gt;
    Set the default xcash (sub-)unit.
  min-outputs-count [n]
    Try to keep at least that many outputs of value at least min-outputs-value.
@@ -2448,8 +2448,8 @@ Avviso: alcune chiavi di input spese vengono da </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
-        <source>xcash, millinero, micronero, nanonero, piconero</source>
-        <translation>xcash, millinero, micronero, nanonero, piconero</translation>
+        <source>xcash, zachy</source>
+        <translation>xcash, zachy</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -1702,7 +1702,7 @@ Om argumentet &quot;tag_description&quot; anges, så tilldelas taggen &lt;taggna
    Set the fee to default/unimportant/normal/elevated/priority.
  confirm-missing-payment-id &lt;1|0>
  ask-password &lt;1|0>
- unit &lt;xcash|millinero|micronero|nanonero|piconero>
+ unit &lt;xcash|zachy>
    Set the default xcash (sub-)unit.
  min-outputs-count [n]
    Try to keep at least that many outputs of value at least min-outputs-value.
@@ -1737,7 +1737,7 @@ Om argumentet &quot;tag_description&quot; anges, så tilldelas taggen &lt;taggna
    Sätt avgiften till default/unimportant/normal/elevated/priority.
  confirm-missing-payment-id &lt;1|0>
  ask-password &lt;1|0>
- unit &lt;xcash|millinero|micronero|nanonero|piconero>
+ unit &lt;xcash|zachy>
    Ange standardvärde för xcashenhet.
  min-outputs-count [n]
    Försök att behålla åtminstone så många utgångar med åtminstone värdet min-outputs-value.
@@ -2609,8 +2609,8 @@ Varning: Några ingångsnycklar som spenderas kommer från </translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1923"/>
-        <source>xcash, millinero, micronero, nanonero, piconero</source>
-        <translation>xcash, millinero, micronero, nanonero, piconero</translation>
+        <source>xcash, zachy</source>
+        <translation>xcash, zachy</translation>
     </message>
     <message>
         <location filename="../src/simplewallet/simplewallet.cpp" line="1975"/>


### PR DESCRIPTION
# Description
- Remove monero units, added zachy unit, changed donate address to testing one, added dns txt records to donate.getxcash.org

Fixes #17 
- Removes unnecessary monero units
- Added zachy unit
- Changed xcash address for donations (previous was an XMR one)
- Make a donation from the wallet

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I've created a new wallet for the donations (just for testing, X-Cash team must change it to one they own), then another with 100 XCASH to make the donation from and test if donation works.

- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
