### PR TITLE
Removing more mining code: miningHashRate, isMining, startMining, stopMining

### DIFF
--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -1164,20 +1164,8 @@ struct WalletManager
     //! returns current network difficulty
     virtual uint64_t networkDifficulty() = 0;
 
-    //! returns current mining hash rate (0 if not mining)
-    virtual double miningHashRate() = 0;
-
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
-
-    //! returns true iff mining
-    virtual bool isMining() = 0;
-
-    //! starts mining with the set number of threads
-    virtual bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) = 0;
-
-    //! stops mining
-    virtual bool stopMining() = 0;
 
     //! resolves an OpenAlias address to a xcash address
     virtual std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const = 0;

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -84,11 +84,7 @@ public:
     uint64_t blockchainHeight() override;
     uint64_t blockchainTargetHeight() override;
     uint64_t networkDifficulty() override;
-    double miningHashRate() override;
     uint64_t blockTarget() override;
-    bool isMining() override;
-    bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) override;
-    bool stopMining() override;
     std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const override;
 
 private:


### PR DESCRIPTION
# Description

When linking **xcash-core libs** to x-cash wallet, compiler was unable to find the following mining functions:

- **miningHashRate**
- **isMining**
- **startMining**
- **stopMining**
 
Removing functions from wallet headers has solved the issue.

## Type of change

- [x] Remove deprecated code

# How Has This Been Tested?

xcash-core was built and tested on the context of Android Wallet

- [x] Functional Tests